### PR TITLE
dune: update stanza to add executable to the package

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -15,6 +15,7 @@
 (executable
   (name wktxt_cmdline)
   (public_name wktxt_cmdline)
+  (package wikitext)
   (modules wktxt_cmdline)
   (libraries wikitext)
 )


### PR DESCRIPTION
This will ensure that `wktxt_cmdline` is installed when building with `dune build -p wikitext` on opam.
It is currently automatic because there is only that package, but in case you add packages or the semantics changes, you have it there explicitly.
